### PR TITLE
feat: use v0.9 talos version for all clusters

### DIFF
--- a/aws/autoscaling-workers/autoscaling-workers.env
+++ b/aws/autoscaling-workers/autoscaling-workers.env
@@ -5,6 +5,7 @@ export SSH_KEY=talos-ssh
 export VPC_ID=vpc-xxyyyzz
 export SUBNET=subnet-xxyyzz
 export K8S_VERSION=1.20.1
+export TALOS_VERSION=v0.9
 
 ## Control plane vars
 export CP_COUNT=3

--- a/aws/autoscaling-workers/autoscaling-workers.yaml
+++ b/aws/autoscaling-workers/autoscaling-workers.yaml
@@ -68,6 +68,7 @@ spec:
   controlPlaneConfig:
     init:
       generateType: init
+      talosVersion: ${TALOS_VERSION}
       configPatches:
         - op: add
           path: /machine/kubelet/extraArgs
@@ -83,6 +84,7 @@ spec:
             - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/master/manifests/aws-cloud-controller-manager-daemonset.yaml
     controlplane:
       generateType: controlplane
+      talosVersion: ${TALOS_VERSION}
       configPatches:
         - op: add
           path: /machine/kubelet/extraArgs
@@ -101,6 +103,7 @@ metadata:
   namespace: default
 spec:
   generateType: join
+  talosVersion: ${TALOS_VERSION}
   configPatches:
     - op: add
       path: /machine/kubelet/extraArgs

--- a/aws/standard/standard.env
+++ b/aws/standard/standard.env
@@ -5,6 +5,7 @@ export SSH_KEY=talos-ssh
 export VPC_ID=vpc-xxyyyzz
 export SUBNET=subnet-xxyyzz
 export K8S_VERSION=1.20.1
+export TALOS_VERSION=v0.9
 
 ## Control plane vars
 export CP_COUNT=3

--- a/aws/standard/standard.yaml
+++ b/aws/standard/standard.yaml
@@ -68,6 +68,7 @@ spec:
   controlPlaneConfig:
     init:
       generateType: init
+      talosVersion: ${TALOS_VERSION}
       configPatches:
         - op: add
           path: /machine/kubelet/extraArgs
@@ -83,6 +84,7 @@ spec:
             - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/master/manifests/aws-cloud-controller-manager-daemonset.yaml
     controlplane:
       generateType: controlplane
+      talosVersion: ${TALOS_VERSION}
       configPatches:
         - op: add
           path: /machine/kubelet/extraArgs
@@ -102,6 +104,7 @@ spec:
   template:
     spec:
       generateType: join
+      talosVersion: ${TALOS_VERSION}
       configPatches:
         - op: add
           path: /machine/kubelet/extraArgs

--- a/gcp/standard/standard.env
+++ b/gcp/standard/standard.env
@@ -1,0 +1,19 @@
+## Cluster-wide vars
+export CLUSTER_NAME=talos-gcp-demo
+export PROJECT=my-testbed
+export REGION=us-central1
+export NETWORK=default
+export K8S_VERSION=1.20.1
+export TALOS_VERSION=v0.9
+
+## Control plane vars
+export CP_COUNT=3
+export CP_INSTANCE_TYPE=n1-standard-4
+export CP_VOL_SIZE=50
+export CP_IMAGE_ID=projects/${PROJECT}/global/images/talos-xxx-yyy
+
+## Worker vars
+export WORKER_COUNT=3
+export WORKER_INSTANCE_TYPE=n1-standard-4
+export WORKER_VOL_SIZE=50
+export WORKER_IMAGE_ID=projects/${PROJECT}/global/images/talos-xxx-yyy

--- a/gcp/standard/standard.yaml
+++ b/gcp/standard/standard.yaml
@@ -46,10 +46,10 @@ spec:
   controlPlaneConfig:
     init:
       generateType: init
-      talosVersion: v0.9
+      talosVersion: ${TALOS_VERSION}
     controlplane:
       generateType: controlplane
-      talosVersion: v0.9
+      talosVersion: ${TALOS_VERSION}
 ---
 kind: GCPMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
@@ -112,4 +112,4 @@ spec:
   template:
     spec:
       generateType: join
-      talosVersion: v0.9
+      talosVersion: ${TALOS_VERSION}


### PR DESCRIPTION
This ensures we generated the proper machine configs to work well in
AWS/GCP.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>