### PR TITLE
fix: ensure we use a tagged version of cloud provider

### DIFF
--- a/aws/autoscaling-workers/autoscaling-workers.env
+++ b/aws/autoscaling-workers/autoscaling-workers.env
@@ -6,6 +6,7 @@ export VPC_ID=vpc-xxyyyzz
 export SUBNET=subnet-xxyyzz
 export K8S_VERSION=1.20.1
 export TALOS_VERSION=v0.9
+export CLOUD_PROVIDER_VERSION=v1.20.0-alpha.0
 
 ## Control plane vars
 export CP_COUNT=3

--- a/aws/autoscaling-workers/autoscaling-workers.yaml
+++ b/aws/autoscaling-workers/autoscaling-workers.yaml
@@ -80,8 +80,8 @@ spec:
         - op: add
           path: /cluster/extraManifests
           value:
-            - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/master/manifests/rbac.yaml
-            - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/master/manifests/aws-cloud-controller-manager-daemonset.yaml
+            - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${CLOUD_PROVIDER_VERSION}/manifests/rbac.yaml
+            - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${CLOUD_PROVIDER_VERSION}/manifests/aws-cloud-controller-manager-daemonset.yaml
     controlplane:
       generateType: controlplane
       talosVersion: ${TALOS_VERSION}

--- a/aws/standard/standard.env
+++ b/aws/standard/standard.env
@@ -6,6 +6,7 @@ export VPC_ID=vpc-xxyyyzz
 export SUBNET=subnet-xxyyzz
 export K8S_VERSION=1.20.1
 export TALOS_VERSION=v0.9
+export CLOUD_PROVIDER_VERSION=v1.20.0-alpha.0
 
 ## Control plane vars
 export CP_COUNT=3

--- a/aws/standard/standard.yaml
+++ b/aws/standard/standard.yaml
@@ -80,8 +80,8 @@ spec:
         - op: add
           path: /cluster/extraManifests
           value:
-            - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/master/manifests/rbac.yaml
-            - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/master/manifests/aws-cloud-controller-manager-daemonset.yaml
+            - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${CLOUD_PROVIDER_VERSION}/manifests/rbac.yaml
+            - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${CLOUD_PROVIDER_VERSION}/manifests/aws-cloud-controller-manager-daemonset.yaml
     controlplane:
       generateType: controlplane
       talosVersion: ${TALOS_VERSION}


### PR DESCRIPTION
This PR makes sure we're using a tag for the AWS cloud provider.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>
