### PR TITLE
feat: add default health check for workers

### DIFF
--- a/aws/standard/standard.yaml
+++ b/aws/standard/standard.yaml
@@ -120,7 +120,7 @@ kind: MachineDeployment
 metadata:
   labels:
     cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
-    nodepool: nodepool-0
+    nodepool: nodepool-a
   name: ${CLUSTER_NAME}-workers
 spec:
   clusterName: ${CLUSTER_NAME}
@@ -128,12 +128,12 @@ spec:
   selector:
     matchLabels:
       cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
-      nodepool: nodepool-0
+      nodepool: nodepool-a
   template:
     metadata:
       labels:
         cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
-        nodepool: nodepool-0
+        nodepool: nodepool-a
     spec:
       clusterName: ${CLUSTER_NAME}
       bootstrap:
@@ -167,3 +167,24 @@ spec:
       additionalSecurityGroups: ${WORKER_ADDL_SEC_GROUPS}
       publicIP: true
       iamInstanceProfile: ${WORKER_IAM_PROFILE}
+---
+## Health check for workers
+
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-worker-hc
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 40%
+  nodeStartupTimeout: 20m
+  selector:
+    matchLabels:
+      nodepool: nodepool-a
+  unhealthyConditions:
+    - type: Ready
+      status: Unknown
+      timeout: 300s
+    - type: Ready
+      status: "False"
+      timeout: 300s


### PR DESCRIPTION
This will make sure a new worker is created if one enters failed state
in the cluster.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>
