### PR TITLE
feat: add template for multi-az clusters

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -16,6 +16,8 @@ Currently supported versions:
 This guide assumes that you have an existing VPC and subnet setup in your AWS environment.
 Unless you have Direct Connect or some VPN to your AWS environment, VMs on this subnet should be allowed to have public IPs so that you can connect to the instances via talosctl.
 
+For the multi-AZ setup, it is assumed that the user has pre-created both private and public subnets for use, as well as a loadbalancer that will be used to target the Talos control plane nodes at port 50000.
+
 ## Preparation
 
 ### Cloud
@@ -23,8 +25,8 @@ Unless you have Direct Connect or some VPN to your AWS environment, VMs on this 
 - In order for the cloud-provider-aws to work properly, you should define two IAM policies in your environment: one for controlplane nodes and one for workers.
 See [here](https://kubernetes.github.io/cloud-provider-aws/prerequisites/) for the defined policies that need to be created.
 
-- Create a security group that allows port 50000 to your VMs.
-This will be necessary in order to connect to these VMs via talosctl.
+- Create a security group that allows port 50000 to your VMs, as well as port 50001 between the VMs themselves.
+This will be necessary in order to connect to these VMs via talosctl and for trustd communication between the VMs.
 
 ### Management Plane
 
@@ -54,7 +56,7 @@ kubectl patch deploy -n capa-system capa-controller-manager --type='json' -p='[{
 
 ## Create cluster
 
-First, using either the [autoscaling](./autoscaling-workers/autoscaling-workers.env) or [standard](./standard/standard.env) environment file as a base, substituting information as necessary to match your AWS environment.
+First, using either the [autoscaling](./autoscaling-workers/autoscaling-workers.env), [multi-az](./multi-az/multi-az.env), or [standard](./standard/standard.env) environment file as a base, substituting information as necessary to match your AWS environment.
 
 - Source the environment variables with `source /path/to/envfile`
 
@@ -63,6 +65,11 @@ First, using either the [autoscaling](./autoscaling-workers/autoscaling-workers.
 For standard:
 ```bash
 clusterctl config cluster ${CLUSTER_NAME} --from https://github.com/talos-systems/cluster-api-templates/blob/main/aws/standard/standard.yaml | kubectl apply -f -
+```
+
+For multi-AZ:
+```bash
+clusterctl config cluster ${CLUSTER_NAME} --from https://github.com/talos-systems/cluster-api-templates/blob/main/aws/multi-az/multi-az.yaml | kubectl apply -f -
 ```
 
 For MachinePools/Autoscaling groups:

--- a/aws/multi-az/multi-az.env
+++ b/aws/multi-az/multi-az.env
@@ -1,0 +1,35 @@
+## Cluster-wide vars
+
+### Subnets
+export PUB_SUB_A='{id: subnet-xxyyzz}'
+export PUB_SUB_B='{id: subnet-xxyyzz}'
+export PUB_SUB_C='{id: subnet-xxyyzz}'
+export PRIV_SUBS='{id: subnet-xxyyzz},{id: subnet-xxyyzz},{id: subnet-xxyyzz}'
+export SUBNETS="[$PUB_SUB_A,$PUB_SUB_B,$PUB_SUB_C,$PRIV_SUBS]"
+
+### Everything Else
+export CLUSTER_NAME=talos-aws-test
+export REGION=us-east-1
+export SSH_KEY=talos-ssh
+export VPC_ID=vpc-xxyyyzz
+export SUBNET=subnet-xxyyzz
+export K8S_VERSION=1.21.0
+export TALOS_VERSION=v0.10
+export CLOUD_PROVIDER_VERSION=v1.20.0-alpha.0
+
+## Control plane vars
+export CP_LB_URL=xxyyzz.elb.us-east-1.amazonaws.com
+export CP_COUNT=3
+export CP_INSTANCE_TYPE=t3.large
+export CP_VOL_SIZE=50
+export CP_AMI_ID=ami-xxyyzz
+export CP_ADDL_SEC_GROUPS='[{id: sg-xxyyzz}]'
+export CP_IAM_PROFILE=CAPI_AWS_ControlPlane
+
+## Worker vars
+export WORKER_COUNT_PER_AZ=1
+export WORKER_INSTANCE_TYPE=t3.large
+export WORKER_VOL_SIZE=50
+export WORKER_AMI_ID=ami-xxyyzz
+export WORKER_ADDL_SEC_GROUPS='[{id: sg-xxyyzz}]'
+export WORKER_IAM_PROFILE=CAPI_AWS_Worker

--- a/aws/multi-az/multi-az.yaml
+++ b/aws/multi-az/multi-az.yaml
@@ -1,0 +1,307 @@
+## Cluster configs
+
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    kind: AWSCluster
+    name: ${CLUSTER_NAME}
+  controlPlaneRef:
+    kind: TalosControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    name: ${CLUSTER_NAME}-controlplane
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AWSCluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  region: ${REGION}
+  sshKeyName: ${SSH_KEY}
+  networkSpec:
+    vpc:
+      id: ${VPC_ID}
+    subnets: ${SUBNETS}
+---
+## Control plane configs
+
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AWSMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-controlplane
+spec:
+  template:
+    spec:
+      cloudInit:
+        insecureSkipSecretsManager: true
+      instanceType: ${CP_INSTANCE_TYPE}
+      rootVolume:
+        size: ${CP_VOL_SIZE}
+      sshKeyName: ${SSH_KEY}
+      ami:
+        id: ${CP_AMI_ID}
+      additionalSecurityGroups: ${CP_ADDL_SEC_GROUPS}
+      iamInstanceProfile: ${CP_IAM_PROFILE}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+kind: TalosControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-controlplane
+spec:
+  version: v${K8S_VERSION}
+  replicas: ${CP_COUNT}
+  infrastructureTemplate:
+    kind: AWSMachineTemplate
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+    name: ${CLUSTER_NAME}-controlplane
+  controlPlaneConfig:
+    init:
+      generateType: init
+      talosVersion: ${TALOS_VERSION}
+      configPatches:
+        - op: add
+          path: /machine/kubelet/registerWithFQDN
+          value: true
+        - op: add
+          path: /cluster/externalCloudProvider
+          value:
+            enabled: true
+            manifests:
+              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${CLOUD_PROVIDER_VERSION}/manifests/rbac.yaml
+              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${CLOUD_PROVIDER_VERSION}/manifests/aws-cloud-controller-manager-daemonset.yaml
+        - op: add
+          path: /machine/certSANs
+          value:
+            - ${CP_LB_URL}
+    controlplane:
+      generateType: controlplane
+      talosVersion: ${TALOS_VERSION}
+      configPatches:
+        - op: add
+          path: /machine/kubelet/registerWithFQDN
+          value: true
+        - op: add
+          path: /cluster/externalCloudProvider
+          value:
+            enabled: true
+            manifests:
+              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${CLOUD_PROVIDER_VERSION}/manifests/rbac.yaml
+              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${CLOUD_PROVIDER_VERSION}/manifests/aws-cloud-controller-manager-daemonset.yaml
+        - op: add
+          path: /machine/certSANs
+          value:
+            - ${CP_LB_URL}
+---
+## Worker deployment configs
+
+### TalosConfigTemplate can be shared across all MachineDeployments
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+kind: TalosConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers
+spec:
+  template:
+    spec:
+      generateType: join
+      talosVersion: ${TALOS_VERSION}
+      configPatches:
+        - op: add
+          path: /machine/kubelet/extraArgs
+          value:
+            cloud-provider: "external"
+        - op: add
+          path: /machine/kubelet/registerWithFQDN
+          value: true
+---
+### Worker group A
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+    nodepool: nodepool-a
+  name: ${CLUSTER_NAME}-workers-a
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_COUNT_PER_AZ}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+      nodepool: nodepool-a
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+        nodepool: nodepool-a
+    spec:
+      clusterName: ${CLUSTER_NAME}
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+          kind: TalosConfigTemplate
+          name: ${CLUSTER_NAME}-workers
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: AWSMachineTemplate
+        name: ${CLUSTER_NAME}-workers-a
+      version: ${K8S_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AWSMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers-a
+spec:
+  template:
+    spec:
+      cloudInit:
+        insecureSkipSecretsManager: true
+      instanceType: ${WORKER_INSTANCE_TYPE}
+      rootVolume:
+        size: ${WORKER_VOL_SIZE}
+      sshKeyName: ${SSH_KEY}
+      ami:
+        id: ${WORKER_AMI_ID}
+      subnet: ${PUB_SUB_A}
+      publicIP: true
+      iamInstanceProfile: ${WORKER_IAM_PROFILE}
+      additionalSecurityGroups: ${WORKER_ADDL_SEC_GROUPS}
+---
+### Worker group B
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+    nodepool: nodepool-b
+  name: ${CLUSTER_NAME}-workers-b
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_COUNT_PER_AZ}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+      nodepool: nodepool-b
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+        nodepool: nodepool-b
+    spec:
+      clusterName: ${CLUSTER_NAME}
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+          kind: TalosConfigTemplate
+          name: ${CLUSTER_NAME}-workers
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: AWSMachineTemplate
+        name: ${CLUSTER_NAME}-workers-b
+      version: ${K8S_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AWSMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers-b
+spec:
+  template:
+    spec:
+      cloudInit:
+        insecureSkipSecretsManager: true
+      instanceType: ${WORKER_INSTANCE_TYPE}
+      rootVolume:
+        size: ${WORKER_VOL_SIZE}
+      sshKeyName: ${SSH_KEY}
+      ami:
+        id: ${WORKER_AMI_ID}
+      subnet: ${PUB_SUB_B}
+      publicIP: true
+      iamInstanceProfile: ${WORKER_IAM_PROFILE}
+      additionalSecurityGroups: ${WORKER_ADDL_SEC_GROUPS}
+---
+### Worker group C
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: MachineDeployment
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+    nodepool: nodepool-c
+  name: ${CLUSTER_NAME}-workers-c
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_COUNT_PER_AZ}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+      nodepool: nodepool-c
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+        nodepool: nodepool-c
+    spec:
+      clusterName: ${CLUSTER_NAME}
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
+          kind: TalosConfigTemplate
+          name: ${CLUSTER_NAME}-workers
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+        kind: AWSMachineTemplate
+        name: ${CLUSTER_NAME}-workers-c
+      version: ${K8S_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AWSMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-workers-c
+spec:
+  template:
+    spec:
+      cloudInit:
+        insecureSkipSecretsManager: true
+      instanceType: ${WORKER_INSTANCE_TYPE}
+      rootVolume:
+        size: ${WORKER_VOL_SIZE}
+      sshKeyName: ${SSH_KEY}
+      ami:
+        id: ${WORKER_AMI_ID}
+      subnet: ${PUB_SUB_C}
+      publicIP: true
+      iamInstanceProfile: ${WORKER_IAM_PROFILE}
+      additionalSecurityGroups: ${WORKER_ADDL_SEC_GROUPS}
+
+---
+## Health check for all workers
+apiVersion: cluster.x-k8s.io/v1alpha3
+kind: MachineHealthCheck
+metadata:
+  name: ${CLUSTER_NAME}-worker-hc
+spec:
+  clusterName: ${CLUSTER_NAME}
+  maxUnhealthy: 40%
+  nodeStartupTimeout: 20m
+  selector:
+    matchExpressions:
+      - {
+          key: nodepool,
+          operator: In,
+          values: [nodepool-a, nodepool-b, nodepool-c],
+        }
+  unhealthyConditions:
+    - type: Ready
+      status: Unknown
+      timeout: 300s
+    - type: Ready
+      status: "False"
+      timeout: 300s
+
+---


### PR DESCRIPTION
This PR adds templates and (admittedly sparse) docs for the multi-az
setup in AWS. Once I have the pulumi code checked into Arges, I'll
provide pointers for folks to be able to create the necessary cloud
infra.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>
