### PR TITLE
feat: drop init configs as they are going to be deprecated

### DIFF
--- a/aws/autoscaling-workers/autoscaling-workers.yaml
+++ b/aws/autoscaling-workers/autoscaling-workers.yaml
@@ -1,6 +1,6 @@
 ## Cluster configs
 
-apiVersion: cluster.x-k8s.io/v1alpha4
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -10,7 +10,7 @@ spec:
       cidrBlocks:
         - 192.168.0.0/16
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AWSCluster
     name: ${CLUSTER_NAME}
   controlPlaneRef:
@@ -18,7 +18,7 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     name: ${CLUSTER_NAME}-controlplane
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSCluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -33,7 +33,7 @@ spec:
 ---
 ## Control plane configs
 
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-controlplane
@@ -63,29 +63,9 @@ spec:
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   infrastructureTemplate:
     kind: AWSMachineTemplate
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     name: ${CLUSTER_NAME}-controlplane
   controlPlaneConfig:
-    init:
-      generateType: init
-      talosVersion: ${TALOS_VERSION}
-      configPatches:
-        - op: add
-          path: /cluster/network/cni
-          value:
-            name: custom
-            urls:
-              - https://docs.projectcalico.org/${CALICO_VERSION}/manifests/calico.yaml
-        - op: add
-          path: /machine/kubelet/registerWithFQDN
-          value: true
-        - op: add
-          path: /cluster/externalCloudProvider
-          value:
-            enabled: true
-            manifests:
-              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${AWS_CLOUD_PROVIDER_VERSION}/manifests/rbac.yaml
-              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${AWS_CLOUD_PROVIDER_VERSION}/manifests/aws-cloud-controller-manager-daemonset.yaml
     controlplane:
       generateType: controlplane
       talosVersion: ${TALOS_VERSION}
@@ -125,7 +105,7 @@ spec:
       value:
         enabled: true
 ---
-apiVersion: exp.cluster.x-k8s.io/v1alpha4
+apiVersion: exp.cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
   name: ${CLUSTER_NAME}-workers
@@ -141,12 +121,12 @@ spec:
           name: ${CLUSTER_NAME}-workers
       clusterName: ${CLUSTER_NAME}
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AWSMachinePool
         name: ${CLUSTER_NAME}-workers
       version: ${KUBERNETES_VERSION}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachinePool
 metadata:
   name: ${CLUSTER_NAME}-workers

--- a/aws/multi-az/multi-az.yaml
+++ b/aws/multi-az/multi-az.yaml
@@ -1,6 +1,6 @@
 ## Cluster configs
 
-apiVersion: cluster.x-k8s.io/v1alpha4
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -10,7 +10,7 @@ spec:
       cidrBlocks:
         - 192.168.0.0/16
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AWSCluster
     name: ${CLUSTER_NAME}
   controlPlaneRef:
@@ -18,7 +18,7 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     name: ${CLUSTER_NAME}-controlplane
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSCluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -32,7 +32,7 @@ spec:
 ---
 ## Control plane configs
 
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-controlplane
@@ -59,33 +59,9 @@ spec:
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   infrastructureTemplate:
     kind: AWSMachineTemplate
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     name: ${CLUSTER_NAME}-controlplane
   controlPlaneConfig:
-    init:
-      generateType: init
-      talosVersion: ${TALOS_VERSION}
-      configPatches:
-        - op: add
-          path: /cluster/network/cni
-          value:
-            name: custom
-            urls:
-              - https://docs.projectcalico.org/${CALICO_VERSION}/manifests/calico.yaml
-        - op: add
-          path: /machine/kubelet/registerWithFQDN
-          value: true
-        - op: add
-          path: /cluster/externalCloudProvider
-          value:
-            enabled: true
-            manifests:
-              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${CLOUD_PROVIDER_VERSION}/manifests/rbac.yaml
-              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${CLOUD_PROVIDER_VERSION}/manifests/aws-cloud-controller-manager-daemonset.yaml
-        - op: add
-          path: /machine/certSANs
-          value:
-            - ${AWS_CONTROL_PLANE_LB_URL}
     controlplane:
       generateType: controlplane
       talosVersion: ${TALOS_VERSION}
@@ -133,7 +109,7 @@ spec:
           value: true
 ---
 ### Worker group A
-apiVersion: cluster.x-k8s.io/v1alpha4
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   labels:
@@ -160,12 +136,12 @@ spec:
           kind: TalosConfigTemplate
           name: ${CLUSTER_NAME}-workers
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AWSMachineTemplate
         name: ${CLUSTER_NAME}-workers-a
       version: ${KUBERNETES_VERSION}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-workers-a
@@ -186,7 +162,7 @@ spec:
       additionalSecurityGroups: ${AWS_NODE_ADDL_SEC_GROUPS}
 ---
 ### Worker group B
-apiVersion: cluster.x-k8s.io/v1alpha4
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   labels:
@@ -213,12 +189,12 @@ spec:
           kind: TalosConfigTemplate
           name: ${CLUSTER_NAME}-workers
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AWSMachineTemplate
         name: ${CLUSTER_NAME}-workers-b
       version: ${KUBERNETES_VERSION}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-workers-b
@@ -239,7 +215,7 @@ spec:
       additionalSecurityGroups: ${AWS_NODE_ADDL_SEC_GROUPS}
 ---
 ### Worker group C
-apiVersion: cluster.x-k8s.io/v1alpha4
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   labels:
@@ -266,12 +242,12 @@ spec:
           kind: TalosConfigTemplate
           name: ${CLUSTER_NAME}-workers
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AWSMachineTemplate
         name: ${CLUSTER_NAME}-workers-c
       version: ${KUBERNETES_VERSION}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-workers-c
@@ -292,7 +268,7 @@ spec:
       additionalSecurityGroups: ${AWS_NODE_ADDL_SEC_GROUPS}
 ---
 ## Health check for all workers
-apiVersion: cluster.x-k8s.io/v1alpha4
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
   name: ${CLUSTER_NAME}-worker-hc

--- a/aws/standard/standard.env
+++ b/aws/standard/standard.env
@@ -4,6 +4,7 @@ export AWS_REGION=us-east-1
 export AWS_SSH_KEY_NAME=talos-ssh
 export AWS_VPC_ID=vpc-xxyyyzz
 export AWS_SUBNET=subnet-xxyyzz
+export AWS_SUBNET_AZ=${AWS_SSH_KEY_NAME}a
 export CALICO_VERSION=v3.18
 export KUBERNETES_VERSION=1.21.0
 export TALOS_VERSION=v0.10

--- a/aws/standard/standard.yaml
+++ b/aws/standard/standard.yaml
@@ -1,5 +1,5 @@
 ## Cluster configs
-apiVersion: cluster.x-k8s.io/v1alpha4
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -9,7 +9,7 @@ spec:
       cidrBlocks:
         - 192.168.0.0/16
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: AWSCluster
     name: ${CLUSTER_NAME}
   controlPlaneRef:
@@ -17,7 +17,7 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     name: ${CLUSTER_NAME}-controlplane
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSCluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -29,9 +29,14 @@ spec:
       id: ${AWS_VPC_ID}
     subnets:
       - id: ${AWS_SUBNET}
+        isPublic: true
+        availabilityZone: ${AWS_SUBNET_AZ}
+  controlPlaneLoadBalancer:
+    subnets:
+      - ${AWS_SUBNET}
 ---
 ## Control plane configs
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-controlplane
@@ -49,8 +54,6 @@ spec:
       additionalSecurityGroups: ${AWS_CONTROL_PLANE_ADDL_SEC_GROUPS}
       publicIP: true
       iamInstanceProfile: ${AWS_CONTROL_PLANE_IAM_PROFILE}
-      subnet:
-        id: ${AWS_SUBNET}
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
 kind: TalosControlPlane
@@ -61,29 +64,9 @@ spec:
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   infrastructureTemplate:
     kind: AWSMachineTemplate
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     name: ${CLUSTER_NAME}-controlplane
   controlPlaneConfig:
-    init:
-      generateType: init
-      talosVersion: ${TALOS_VERSION}
-      configPatches:
-        - op: add
-          path: /cluster/network/cni
-          value:
-            name: custom
-            urls:
-              - https://docs.projectcalico.org/${CALICO_VERSION}/manifests/calico.yaml
-        - op: add
-          path: /machine/kubelet/registerWithFQDN
-          value: true
-        - op: add
-          path: /cluster/externalCloudProvider
-          value:
-            enabled: true
-            manifests:
-              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${AWS_CLOUD_PROVIDER_VERSION}/manifests/rbac.yaml
-              - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/${AWS_CLOUD_PROVIDER_VERSION}/manifests/aws-cloud-controller-manager-daemonset.yaml
     controlplane:
       generateType: controlplane
       talosVersion: ${TALOS_VERSION}
@@ -124,7 +107,7 @@ spec:
           value:
             enabled: true
 ---
-apiVersion: cluster.x-k8s.io/v1alpha4
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   labels:
@@ -151,12 +134,12 @@ spec:
           kind: TalosConfigTemplate
           name: ${CLUSTER_NAME}-workers
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AWSMachineTemplate
         name: ${CLUSTER_NAME}-workers
       version: ${KUBERNETES_VERSION}
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AWSMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-workers
@@ -171,14 +154,12 @@ spec:
       sshKeyName: ${AWS_SSH_KEY_NAME}
       ami:
         id: ${AWS_NODE_AMI_ID}
-      subnet:
-        id: ${AWS_SUBNET}
       additionalSecurityGroups: ${AWS_NODE_ADDL_SEC_GROUPS}
       publicIP: true
       iamInstanceProfile: ${AWS_NODE_IAM_PROFILE}
 ---
 ## Health check for workers
-apiVersion: cluster.x-k8s.io/v1alpha4
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck
 metadata:
   name: ${CLUSTER_NAME}-worker-hc

--- a/gcp/standard/standard.yaml
+++ b/gcp/standard/standard.yaml
@@ -1,7 +1,7 @@
 ---
 ## Cluster configs
 
-apiVersion: cluster.x-k8s.io/v1alpha4
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -10,7 +10,7 @@ spec:
     pods:
       cidrBlocks: ["192.168.0.0/16"]
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: GCPCluster
     name: ${CLUSTER_NAME}
   controlPlaneRef:
@@ -18,7 +18,7 @@ spec:
     apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
     name: ${CLUSTER_NAME}-controlplane
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: GCPCluster
 metadata:
   name: ${CLUSTER_NAME}
@@ -39,18 +39,15 @@ spec:
   replicas: ${CONTROL_PLANE_MACHINE_COUNT}
   infrastructureTemplate:
     kind: GCPMachineTemplate
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     name: ${CLUSTER_NAME}-controlplane
   controlPlaneConfig:
-    init:
-      generateType: init
-      talosVersion: ${TALOS_VERSION}
     controlplane:
       generateType: controlplane
       talosVersion: ${TALOS_VERSION}
 ---
 kind: GCPMachineTemplate
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 metadata:
   name: ${CLUSTER_NAME}-controlplane
 spec:
@@ -67,7 +64,7 @@ spec:
 ---
 ## Worker configs
 
-apiVersion: cluster.x-k8s.io/v1alpha4
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   labels:
@@ -97,10 +94,10 @@ spec:
           kind: TalosConfigTemplate
       infrastructureRef:
         name: ${CLUSTER_NAME}-workers
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: GCPMachineTemplate
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: GCPMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-workers


### PR DESCRIPTION
Related https://github.com/talos-systems/cluster-api-control-plane-provider-talos/issues/74

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>
Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>